### PR TITLE
Add display of Processing Note

### DIFF
--- a/packages/collections/templates/scarc/collection.inc.php
+++ b/packages/collections/templates/scarc/collection.inc.php
@@ -296,6 +296,18 @@ if(defined('PACKAGE_DIGITALLIBRARY'))
   }
 
   /**
+   * Statement on Description / Processing Info
+   */
+  if ($objCollection->ProcessingInfo) {
+    ?>
+    <div class='ccardcontent'><span
+        class='ccardlabel'><?php echo $_ARCHON->getPhrase('processing_note', PACKAGE_COLLECTIONS, 0, PHRASETYPE_PUBLIC)
+          ->getPhraseValue(ENCODE_HTML); ?></span> <?php echo($objCollection->getString('ProcessingInfo')); ?>
+    </div>
+  <?php
+  }
+
+  /**
    * More Information
    */
   if ($objCollection->Arrangement) {


### PR DESCRIPTION
Fixes #165 

Live on Production as 'Statement on Description':
![image](https://user-images.githubusercontent.com/2293544/103376967-de49ef00-4a92-11eb-8488-1cc7e7d0233a.png)